### PR TITLE
Removes unused rangers from the database

### DIFF
--- a/wildlife_db.sql
+++ b/wildlife_db.sql
@@ -98,6 +98,10 @@ SELECT
     END AS time_of_day
 FROM sightings;
 
-
+--Problem 9
+DELETE FROM rangers
+WHERE ranger_id NOT IN (
+  SELECT DISTINCT ranger_id FROM sightings
+);
 
 


### PR DESCRIPTION
Deletes rangers whose IDs are not referenced in the sightings table, ensuring data consistency by removing orphaned records.